### PR TITLE
manim-latex: added some more missing packages

### DIFF
--- a/manim-latex/tools/chocolateyinstall.ps1
+++ b/manim-latex/tools/chocolateyinstall.ps1
@@ -4,6 +4,6 @@ Start-ChocolateyProcessAsAdmin `
   -Statements "tlmgr update --self" `
   -Elevated
 Start-ChocolateyProcessAsAdmin `
-  -Statements "tlmgr install standalone everysel ctex frcursive preview doublestroke ms setspace rsfs relsize ragged2e fundus-calligra microtype wasysym physics dvisvgm jknapltx wasy cm-super babel-english gnu-freefont mathastext cbfonts-fd" `
+  -Statements "tlmgr install amsmath fontspec latex-bin tipa xcolor xetex xkeyval standalone everysel ctex frcursive preview doublestroke ms setspace rsfs relsize ragged2e fundus-calligra microtype wasysym physics dvisvgm jknapltx wasy cm-super babel-english gnu-freefont mathastext cbfonts-fd" `
   -Elevated
 


### PR DESCRIPTION
Did a diff against the [docs](https://docs.manim.community/en/stable/installation/windows.html#optional-dependencies) and added the rest.